### PR TITLE
add lib names for MacOSX

### DIFF
--- a/libtcod_nim/private/libtcod_define.nim
+++ b/libtcod_nim/private/libtcod_define.nim
@@ -36,6 +36,11 @@ when defined(linux):
     const LIB_NAME* = "libtcod_debug.so"
   else:
     const LIB_NAME* = "libtcod.so"
+elif defined(MacOSX):
+  when defined(debug):
+    const LIB_NAME* = "libtcod_debug.dylib"
+  else:
+    const LIB_NAME* = "libtcod.dylib"
 else: # windows
   when defined(debug):
     const LIB_NAME* = "libtcod-mingw-debug.dll"


### PR DESCRIPTION
- tested on OSX 10.10 and 10.11
- using homebrew's libtcod 1.5.1
- all examples work
- switching to fullscreen fails with SIGSEGV, but starting with -fullscreen works about every fourth time